### PR TITLE
refactor: set option defaults and add more js docs

### DIFF
--- a/packages/cron/README.md
+++ b/packages/cron/README.md
@@ -56,7 +56,7 @@ const options = {
 		 * The timezone to use for the cron tasks
 		 * @default 'UTC'
 		 */
-		timeZone: 'Europe/London'
+		defaultTimezone: 'Europe/London'
 	}
 };
 ```
@@ -122,7 +122,7 @@ The `CronTask` class provides logging helpers that are similar to the ones provi
 
 This is an example of how to use the `info` helper:
 
-```ts
+```typescript
 import { CronTask } from '@kingsworld/plugin-cron';
 
 export class PingPong extends CronTask {

--- a/packages/cron/src/lib/CronTaskHandler.ts
+++ b/packages/cron/src/lib/CronTaskHandler.ts
@@ -3,23 +3,53 @@ import type Sentry from '@sentry/node';
 import type { CronTaskHandlerOptions } from './types/CronTaskTypes';
 
 export class CronTaskHandler {
-	public defaultTimezone?: CronTaskHandlerOptions['defaultTimezone'];
-	public disableSentry?: boolean;
+	/**
+	 * The default timezone to use for all cron tasks.
+	 * You can override this per task, using the timeZone option.
+	 * @see https://github.com/moment/luxon/blob/master/docs/zones.md#specifying-a-zone
+	 * @see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+	 * @default 'UTC'
+	 */
+	public defaultTimezone: CronTaskHandlerOptions['defaultTimezone'];
+
+	/**
+	 * The ability to opt-out of instrumenting cron jobs with Sentry.
+	 * If you don't use Sentry, you can ignore this option.
+	 * @see https://docs.sentry.io/product/crons/
+	 * @default false
+	 */
+	public disableSentry: boolean;
+
+	/**
+	 * The Sentry instance to use for instrumenting cron jobs.
+	 * This is only available when [`@sentry/node`](https://www.npmjs.com/package/@sentry/node)
+	 * is installed and the {@linkcode disableSentry} option is set to false.
+	 */
 	public sentry?: typeof Sentry;
 
 	public constructor(options?: CronTaskHandlerOptions) {
-		this.defaultTimezone = options?.defaultTimezone;
-		this.disableSentry = options?.disableSentry;
+		this.defaultTimezone = options?.defaultTimezone ?? 'UTC';
+		this.disableSentry = options?.disableSentry ?? false;
 	}
 
+	/**
+	 * Start all enabled cron jobs.
+	 * This gets called automatically when the Client is ready.
+	 */
 	public startAll() {
 		this.store.startAll();
 	}
 
+	/**
+	 * Stop all running cron jobs.
+	 */
 	public stopAll() {
 		this.store.stopAll();
 	}
 
+	/**
+	 * Get the cron task store.
+	 */
 	private get store() {
 		return container.stores.get('cron-tasks');
 	}

--- a/packages/cron/src/lib/structures/CronTask.ts
+++ b/packages/cron/src/lib/structures/CronTask.ts
@@ -3,6 +3,27 @@ import { Piece } from '@sapphire/pieces';
 import type { CronJob } from 'cron';
 import type { CronJobOptions } from '../types/CronTaskTypes';
 
+/**
+ * @example
+ *
+ * ```typescript
+ * // ping.ts
+ * import { CronTask } from '@kingsworld/plugin-cron';
+ *
+ * export class PingPong extends CronTask {
+ * 	public constructor(context: CronTask.LoaderContext, options: CronTask.Options) {
+ * 		super(context, {
+ * 			...options,
+ * 			cronTime: '* * * * *'
+ * 		});
+ * 	}
+ *
+ * 	public run() {
+ * 		this.info('Ping Pong! 🏓'); // CronTask[ping] Ping Pong! 🏓
+ * 	}
+ * }
+ * ```
+ */
 export abstract class CronTask<Options extends CronTask.Options = CronTask.Options> extends Piece<Options, 'cron-tasks'> {
 	public declare job: CronJob<null, CronTask>;
 
@@ -12,22 +33,57 @@ export abstract class CronTask<Options extends CronTask.Options = CronTask.Optio
 
 	public abstract run(): Awaitable<unknown>;
 
+	/**
+	 * A helper function to log messages with the `CronTask[${name}]` prefix.
+	 * @param message The message to include after the prefix
+	 * @param other Extra parameters to pass to the logger
+	 * @example
+	 * this.info('Hello world!'); // CronTask[my-task] Hello world!
+	 */
 	public info(message: string, ...other: unknown[]) {
 		this.container.logger.info(`CronTask[${this.name}] ${message}`, ...other);
 	}
 
+	/**
+	 * A helper function to log messages with the `CronTask[${name}]` prefix.
+	 * @param message The message to include after the prefix
+	 * @param other Extra parameters to pass to the logger
+	 * @example
+	 * this.error('Something went wrong!'); // CronTask[my-task] Something went wrong!
+	 */
 	public error(message: string, ...other: unknown[]) {
 		this.container.logger.error(`CronTask[${this.name}] ${message}`, ...other);
 	}
 
+	/**
+	 * A helper function to log messages with the `CronTask[${name}]` prefix.
+	 * @param message The message to include after the prefix
+	 * @param other Extra parameters to pass to the logger
+	 * @example
+	 * this.warn('Something is not right!'); // CronTask[my-task] Something is not right!
+	 */
 	public warn(message: string, ...other: unknown[]) {
 		this.container.logger.warn(`CronTask[${this.name}] ${message}`, ...other);
 	}
 
+	/**
+	 * A helper function to log messages with the `CronTask[${name}]` prefix.
+	 * @param message The message to include after the prefix
+	 * @param other Extra parameters to pass to the logger
+	 * @example
+	 * this.debug('Something is happening!'); // CronTask[my-task] Something is happening!
+	 */
 	public debug(message: string, ...other: unknown[]) {
 		this.container.logger.debug(`CronTask[${this.name}] ${message}`, ...other);
 	}
 
+	/**
+	 * A helper function to log messages with the `CronTask[${name}]` prefix.
+	 * @param message The message to include after the prefix
+	 * @param other Extra parameters to pass to the logger
+	 * @example
+	 * this.trace('Loaded the file.'); // CronTask[my-task] Loaded the file.
+	 */
 	public trace(message: string, ...other: unknown[]) {
 		this.container.logger.trace(`CronTask[${this.name}] ${message}`, ...other);
 	}

--- a/packages/cron/src/lib/structures/CronTaskStore.ts
+++ b/packages/cron/src/lib/structures/CronTaskStore.ts
@@ -7,6 +7,11 @@ export class CronTaskStore extends Store<CronTask, 'cron-tasks'> {
 		super(CronTask, { name: 'cron-tasks' });
 	}
 
+	/**
+	 * Loops over all tasks and starts those that are enabled.
+	 * This gets called automatically when the Client is ready.
+	 * @returns CronTaskStore
+	 */
 	public startAll() {
 		for (const task of this.values()) {
 			if (!task.enabled) continue;
@@ -17,6 +22,10 @@ export class CronTaskStore extends Store<CronTask, 'cron-tasks'> {
 		return this;
 	}
 
+	/**
+	 * Loops over all tasks and stops those that are running.
+	 * @returns CronTaskStore
+	 */
 	public stopAll() {
 		for (const task of this.values()) {
 			if (!task.job.running) continue;
@@ -58,6 +67,10 @@ export class CronTaskStore extends Store<CronTask, 'cron-tasks'> {
 		return super.delete(key);
 	}
 
+	/**
+	 * Stops all running cron jobs and clears the store.
+	 * @returns void
+	 */
 	public override clear() {
 		this.stopAll();
 		return super.clear();

--- a/packages/cron/src/lib/types/CronTaskTypes.ts
+++ b/packages/cron/src/lib/types/CronTaskTypes.ts
@@ -5,18 +5,19 @@ export interface CronTaskHandlerOptions {
 	/**
 	 * The default timezone to use for all cron tasks.
 	 * You can override this per task, using the timeZone option.
+	 * @see https://github.com/moment/luxon/blob/master/docs/zones.md#specifying-a-zone
 	 * @see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-	 * @default "UTC"
+	 * @default 'UTC'
 	 */
-	defaultTimezone?: string;
+	defaultTimezone: string;
 
 	/**
 	 * The ability to opt-out of instrumenting cron jobs with Sentry.
 	 * If you don't use Sentry, you can ignore this option.
 	 * @see https://docs.sentry.io/product/crons/
-	 * @default undefined // technically false
+	 * @default false
 	 */
-	disableSentry?: boolean;
+	disableSentry: boolean;
 }
 
 export type CronJobOptions = Omit<CronJobParams<null, CronTask>, 'onTick' | 'onComplete' | 'start' | 'context' | 'utcOffset'>;


### PR DESCRIPTION
- Adds more JSDocs and include examples
- Sets the default values for the `defaultTimezone` and `disableSentry` options to match their JSDoc defaults
- Fixes timezone option having the wrong name in the readme