### PR TITLE
fix: use luxon's system default instead of utc

### DIFF
--- a/packages/cron/README.md
+++ b/packages/cron/README.md
@@ -54,7 +54,7 @@ const options = {
 		disableSentry: false,
 		/**
 		 * The timezone to use for the cron tasks
-		 * @default 'UTC'
+		 * @default 'system'
 		 */
 		defaultTimezone: 'Europe/London'
 	}

--- a/packages/cron/src/lib/CronTaskHandler.ts
+++ b/packages/cron/src/lib/CronTaskHandler.ts
@@ -7,8 +7,7 @@ export class CronTaskHandler {
 	 * The default timezone to use for all cron tasks.
 	 * You can override this per task, using the timeZone option.
 	 * @see https://github.com/moment/luxon/blob/master/docs/zones.md#specifying-a-zone
-	 * @see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-	 * @default 'UTC'
+	 * @default 'system'
 	 */
 	public defaultTimezone: CronTaskHandlerOptions['defaultTimezone'];
 
@@ -28,7 +27,7 @@ export class CronTaskHandler {
 	public sentry?: typeof Sentry;
 
 	public constructor(options?: CronTaskHandlerOptions) {
-		this.defaultTimezone = options?.defaultTimezone ?? 'UTC';
+		this.defaultTimezone = options?.defaultTimezone ?? 'system';
 		this.disableSentry = options?.disableSentry ?? false;
 	}
 

--- a/packages/cron/src/lib/types/CronTaskTypes.ts
+++ b/packages/cron/src/lib/types/CronTaskTypes.ts
@@ -6,8 +6,7 @@ export interface CronTaskHandlerOptions {
 	 * The default timezone to use for all cron tasks.
 	 * You can override this per task, using the timeZone option.
 	 * @see https://github.com/moment/luxon/blob/master/docs/zones.md#specifying-a-zone
-	 * @see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-	 * @default 'UTC'
+	 * @default 'system'
 	 */
 	defaultTimezone: string;
 


### PR DESCRIPTION
The cron package uses Luxon for dates. Therefore, I am switching the default to match Luxon's default zone.

https://github.com/moment/luxon/blob/3e9983cd0680fdf7836fcee638d34e3edc682380/src/settings.js#L11C18-L11C24
> ```ts
> defaultZone = "system",
> ```

https://github.com/moment/luxon/blob/3e9983cd0680fdf7836fcee638d34e3edc682380/src/zones/systemZone.js#L29
> ```ts
> return new Intl.DateTimeFormat().resolvedOptions().timeZone;
> ```