### PR TITLE
fix: use the partial helper to make options optional

### DIFF
--- a/packages/cron/src/lib/CronTaskHandler.ts
+++ b/packages/cron/src/lib/CronTaskHandler.ts
@@ -26,7 +26,7 @@ export class CronTaskHandler {
 	 */
 	public sentry?: typeof Sentry;
 
-	public constructor(options?: CronTaskHandlerOptions) {
+	public constructor(options?: Partial<CronTaskHandlerOptions>) {
 		this.defaultTimezone = options?.defaultTimezone ?? 'system';
 		this.disableSentry = options?.disableSentry ?? false;
 	}


### PR DESCRIPTION
I changed CronTaskHandlerOptions to not be optional properties with the intention of using the partial helper type. however, i completely forgot to actually use it.