### PR TITLE
fix(cron): correctly handle the sentry import

### DIFF
--- a/packages/cron/src/register.ts
+++ b/packages/cron/src/register.ts
@@ -15,7 +15,7 @@ export class CronTaskPlugin extends Plugin {
 
 	public static async [preLogin](this: SapphireClient) {
 		if (container.cron.disableSentry) return;
-		container.cron.sentry = await import('@sentry/node').then((mod) => mod.default).catch(() => undefined);
+		container.cron.sentry = await import('@sentry/node').catch(() => undefined);
 	}
 
 	public static [postLogin](this: SapphireClient) {


### PR DESCRIPTION
Fixes #46

Fixes my mistaken need of the default property to access Sentry's object.