### PR TITLE
feat: format luxon timezones to their tz identifier

### DIFF
--- a/packages/cron/package.json
+++ b/packages/cron/package.json
@@ -52,6 +52,7 @@
 		"@favware/cliff-jumper": "^4.1.0",
 		"@favware/rollup-type-bundler": "^3.3.0",
 		"@sentry/node": "^8.30.0",
+		"@types/luxon": "^3.4.2",
 		"@types/node": "^20.16.5",
 		"concurrently": "^9.0.1",
 		"tsup": "^8.3.0",

--- a/packages/cron/src/lib/structures/CronTaskStore.ts
+++ b/packages/cron/src/lib/structures/CronTaskStore.ts
@@ -1,6 +1,7 @@
 import { Store } from '@sapphire/pieces';
 import { CronJob } from 'cron';
 import { CronTask } from './CronTask';
+import { Info, DateTime, FixedOffsetZone, type Zone } from 'luxon';
 
 export class CronTaskStore extends Store<CronTask, 'cron-tasks'> {
 	public constructor() {
@@ -48,7 +49,7 @@ export class CronTaskStore extends Store<CronTask, 'cron-tasks'> {
 				onTick: () => void value.run.bind(value)(),
 				start: false,
 				context: value,
-				timeZone: options.timeZone ?? defaultTimezone
+				timeZone: this.formatLuxonZone(options.timeZone ?? defaultTimezone)
 			});
 		} catch (error) {
 			value.error('Encountered an error while creating the cron job', error);
@@ -74,5 +75,25 @@ export class CronTaskStore extends Store<CronTask, 'cron-tasks'> {
 	public override clear() {
 		this.stopAll();
 		return super.clear();
+	}
+
+	/**
+	 * Formats a Luxon-compatible timezone string into a TZ timezone string.
+	 * This is required because Sentry requires time zones to be in TZ format.
+	 * @param timezone The Luxon-compatible timezone to format.
+	 * @returns The formatted TZ timezone.
+	 * @private
+	 */
+	private formatLuxonZone(timezone?: string | Zone | number) {
+		const zone = Info.normalizeZone(timezone);
+
+		// If the zone is invalid, return the system zone
+		if (!zone.isValid) return DateTime.local().zoneName;
+
+		// If the zone is a fixed offset zone, return the IANA name
+		if (zone instanceof FixedOffsetZone) return zone.ianaName;
+
+		// Otherwise, return the zone name
+		return zone.name;
 	}
 }

--- a/packages/cron/src/lib/types/CronTaskTypes.ts
+++ b/packages/cron/src/lib/types/CronTaskTypes.ts
@@ -20,3 +20,17 @@ export interface CronTaskHandlerOptions {
 }
 
 export type CronJobOptions = Omit<CronJobParams<null, CronTask>, 'onTick' | 'onComplete' | 'start' | 'context' | 'utcOffset'>;
+
+/**
+ * The @types/luxon package doesn't seem to be up-to-date with luxon.
+ * Therefore, I have to manually add the ianaName getter to the FixedOffsetZone class.
+ * The code can be found here: https://github.com/moment/luxon/blob/3e9983cd0680fdf7836fcee638d34e3edc682380/src/zones/fixedOffsetZone.js#L80C7-L80C15
+ */
+declare module 'luxon' {
+	interface FixedOffsetZone {
+		/**
+		 * The IANA name of this zone, i.e. `Etc/UTC` or `Etc/GMT+/-nn`
+		 */
+		get ianaName(): string;
+	}
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -692,6 +692,7 @@ __metadata:
     "@favware/cliff-jumper": "npm:^4.1.0"
     "@favware/rollup-type-bundler": "npm:^3.3.0"
     "@sentry/node": "npm:^8.30.0"
+    "@types/luxon": "npm:^3.4.2"
     "@types/node": "npm:^20.16.5"
     concurrently: "npm:^9.0.1"
     cron: "npm:^3.1.7"
@@ -1691,7 +1692,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/luxon@npm:~3.4.0":
+"@types/luxon@npm:^3.4.2, @types/luxon@npm:~3.4.0":
   version: 3.4.2
   resolution: "@types/luxon@npm:3.4.2"
   checksum: 10/fd89566e3026559f2bc4ddcc1e70a2c16161905ed50be9473ec0cfbbbe919165041408c4f6e06c4bcf095445535052e2c099087c76b1b38e368127e618fc968d


### PR DESCRIPTION
Sentry requires the TZ timezone to be used

I have made an issue with Sentry to see if its something that they would implement. However, a staff member was unsure about it, thus suggesting that it would be something we ourselves would have to deal with.

The issue can be found here: https://github.com/getsentry/sentry-javascript/issues/13820