### PR TITLE
refactor(cron)!: replace the cron package with croner

### DIFF
--- a/packages/cron/README.md
+++ b/packages/cron/README.md
@@ -2,7 +2,7 @@
 
 # @kingsworld/plugin-cron
 
-**Plugin for <a href="https://github.com/sapphiredev/framework">@sapphire/framework</a> to add support for cron tasks using <a href="https://github.com/kelektiv/node-cron">cron</a>.**
+**Plugin for <a href="https://github.com/sapphiredev/framework">@sapphire/framework</a> to add support for cron tasks using <a href="https://github.com/Hexagon/croner">croner</a>.**
 
 [![GitHub](https://img.shields.io/github/license/Kings-World/sapphire-plugins)](https://github.com/Kings-World/sapphire-plugins/blob/main/LICENSE.md)
 [![npm bundle size](https://pkg-size.dev/badge/bundle/83411)](https://pkg-size.dev/@kingsworld/plugin-cron)
@@ -46,7 +46,7 @@ Then, you can configure the plugin in the configuration options in your Sapphire
 ```ts
 const options = {
 	...otherClientOptionsGoHere,
-	cron: {
+	cronTasks: {
 		/**
 		 * Whether to disable Sentry cron monitoring
 		 * @default false
@@ -54,7 +54,7 @@ const options = {
 		disableSentry: false,
 		/**
 		 * The timezone to use for the cron tasks
-		 * @default 'system'
+		 * @default undefined
 		 */
 		defaultTimezone: 'Europe/London'
 	}
@@ -63,30 +63,38 @@ const options = {
 
 - The `disableSentry` option is used to disable Sentry's cron monitoring. By default, it is set to `false`, which means Sentry cron monitoring is enabled if the `@sentry/node` package is installed and configured. This makes using Sentry an opt-in feature - you first opt in by installing `@sentry/node`. The `disableSentry` option then allows you to opt out in specific situations. You can set this to `true` to disable cron monitoring, which can be useful during development or if you haven't provided a Sentry DSN. If you don't use Sentry at all (i.e., `@sentry/node` is not installed), this option has no effect and can be safely ignored.
 
-In order to use the cron tasks anywhere other than a piece (commands, arguments, preconditions, etc.), you must first import the `container` property of `@sapphire/framework`. For pieces, you can simply use `this.container.cron` to access this plugin's methods.
+In order to use the cron tasks anywhere other than a piece (commands, arguments, preconditions, etc.), you must first import the `container` property of `@sapphire/framework`. From there, you can access the store.
 
-This is a simple example of how to start a task from a service.
+This is a simple example of how to pause and resume a task from a service.
 
 ```typescript
 import { container } from '@sapphire/framework';
 
 export class MyAwesomeService {
 	public createAwesomeTask() {
-		const task = container.cron.store.get('my-awesome-task');
+		const task = container.stores.get('cron-tasks').get('my-awesome-task');
 
-		task.job.start();
+		// To pause the task:
+		task.job.pause();
+
+		// To resume the task:
+		task.job.resume();
 	}
 }
 ```
 
-This is a simple example of how to start all tasks from a service.
+This is a simple example of how to pause or resume all tasks from a service.
 
 ```typescript
 import { container } from '@sapphire/framework';
 
 export class MyAwesomeService {
 	public createAwesomeTask() {
-		container.cron.startAll();
+		// To pause all tasks:
+		container.stores.get('cron-tasks').pauseAll();
+
+		// To resume all tasks:
+		container.stores.get('cron-tasks').resumeAll();
 	}
 }
 ```
@@ -106,7 +114,7 @@ export class PingPong extends CronTask {
 	public constructor(context: CronTask.LoaderContext, options: CronTask.Options) {
 		super(context, {
 			...options,
-			cronTime: '* * * * *'
+			pattern: '* * * * *'
 		});
 	}
 
@@ -129,7 +137,7 @@ export class PingPong extends CronTask {
 	public constructor(context: CronTask.LoaderContext, options: CronTask.Options) {
 		super(context, {
 			...options,
-			cronTime: '* * * * *'
+			pattern: '* * * * *'
 		});
 	}
 

--- a/packages/cron/package.json
+++ b/packages/cron/package.json
@@ -46,7 +46,8 @@
 		"check-update": "cliff-jumper --dry-run"
 	},
 	"dependencies": {
-		"cron": "^4.1.3"
+		"cron": "^4.1.3",
+		"croner": "^9.0.0"
 	},
 	"devDependencies": {
 		"@favware/cliff-jumper": "^6.0.0",

--- a/packages/cron/package.json
+++ b/packages/cron/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@kingsworld/plugin-cron",
 	"description": "A simple @sapphire/framework plugin that aims to make use of the cron package and allow users to make cron jobs within their Sapphire discord bot.",
-	"version": "2.1.1",
+	"version": "3.0.1",
 	"author": "Seren_Modz 21 <seren@kings-world.net>",
 	"license": "MIT",
 	"main": "dist/cjs/index.cjs",

--- a/packages/cron/package.json
+++ b/packages/cron/package.json
@@ -46,14 +46,12 @@
 		"check-update": "cliff-jumper --dry-run"
 	},
 	"dependencies": {
-		"cron": "^4.1.3",
 		"croner": "^9.0.0"
 	},
 	"devDependencies": {
 		"@favware/cliff-jumper": "^6.0.0",
 		"@favware/rollup-type-bundler": "^4.0.0",
 		"@sentry/node": "^9.11.0",
-		"@types/luxon": "^3.6.2",
 		"@types/node": "^22.14.0",
 		"concurrently": "^9.1.2",
 		"tsup": "^8.4.0",

--- a/packages/cron/src/index.ts
+++ b/packages/cron/src/index.ts
@@ -9,7 +9,7 @@ export * from './lib/types/CronTaskTypes';
 
 declare module '@sapphire/pieces' {
 	interface Container {
-		cron: CronTaskHandler;
+		cronTasks: CronTaskHandler;
 	}
 
 	interface StoreRegistryEntries {
@@ -19,7 +19,7 @@ declare module '@sapphire/pieces' {
 
 declare module 'discord.js' {
 	export interface ClientOptions {
-		cron?: Partial<CronTaskHandlerOptions>;
+		cronTasks?: Partial<CronTaskHandlerOptions>;
 	}
 }
 

--- a/packages/cron/src/lib/CronTaskHandler.ts
+++ b/packages/cron/src/lib/CronTaskHandler.ts
@@ -1,15 +1,12 @@
-import { container } from '@sapphire/framework';
 import type Sentry from '@sentry/node';
 import type { CronTaskHandlerOptions } from './types/CronTaskTypes';
 
 export class CronTaskHandler {
 	/**
-	 * The default timezone to use for all cron tasks.
-	 * You can override this per task, using the timeZone option.
-	 * @see https://github.com/moment/luxon/blob/master/docs/zones.md#specifying-a-zone
-	 * @default 'system'
+	 * The default IANA timezone to use for all cron jobs.
+	 * You can override this per task, using the timezone option.
 	 */
-	public defaultTimezone: CronTaskHandlerOptions['defaultTimezone'];
+	public defaultTimezone?: CronTaskHandlerOptions['defaultTimezone'];
 
 	/**
 	 * The ability to opt-out of instrumenting cron jobs with Sentry.
@@ -27,29 +24,7 @@ export class CronTaskHandler {
 	public sentry?: typeof Sentry;
 
 	public constructor(options?: Partial<CronTaskHandlerOptions>) {
-		this.defaultTimezone = options?.defaultTimezone ?? 'system';
+		this.defaultTimezone = options?.defaultTimezone;
 		this.disableSentry = options?.disableSentry ?? false;
-	}
-
-	/**
-	 * Start all enabled cron jobs.
-	 * This gets called automatically when the Client is ready.
-	 */
-	public startAll() {
-		this.store.startAll();
-	}
-
-	/**
-	 * Stop all running cron jobs.
-	 */
-	public stopAll() {
-		this.store.stopAll();
-	}
-
-	/**
-	 * Get the cron task store.
-	 */
-	private get store() {
-		return container.stores.get('cron-tasks');
 	}
 }

--- a/packages/cron/src/lib/CronTaskHandler.ts
+++ b/packages/cron/src/lib/CronTaskHandler.ts
@@ -3,8 +3,9 @@ import type { CronTaskHandlerOptions } from './types/CronTaskTypes';
 
 export class CronTaskHandler {
 	/**
-	 * The default IANA timezone to use for all cron jobs.
+	 * The default IANA/TZ timezone to use for all cron jobs.
 	 * You can override this per task, using the timezone option.
+	 * @see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 	 */
 	public defaultTimezone?: CronTaskHandlerOptions['defaultTimezone'];
 

--- a/packages/cron/src/lib/structures/CronTask.ts
+++ b/packages/cron/src/lib/structures/CronTask.ts
@@ -33,6 +33,10 @@ export abstract class CronTask<Options extends CronTask.Options = CronTask.Optio
 
 	public abstract run(): Awaitable<unknown>;
 
+	public abstract protect?(job: Cron): Awaitable<unknown>;
+
+	public abstract catch?(error: unknown, job: Cron): Awaitable<unknown>;
+
 	/**
 	 * A helper function to log messages with the `CronTask[${name}]` prefix.
 	 * @param message The message to include after the prefix

--- a/packages/cron/src/lib/structures/CronTask.ts
+++ b/packages/cron/src/lib/structures/CronTask.ts
@@ -1,6 +1,6 @@
 import type { Awaitable } from '@sapphire/framework';
 import { Piece } from '@sapphire/pieces';
-import type { CronJob } from 'cron';
+import type { Cron } from 'croner';
 import type { CronJobOptions } from '../types/CronTaskTypes';
 
 /**
@@ -25,7 +25,7 @@ import type { CronJobOptions } from '../types/CronTaskTypes';
  * ```
  */
 export abstract class CronTask<Options extends CronTask.Options = CronTask.Options> extends Piece<Options, 'cron-tasks'> {
-	declare public job: CronJob<null, CronTask>;
+	declare public job: Cron;
 
 	public constructor(context: CronTask.LoaderContext, options: Options) {
 		super(context, options);

--- a/packages/cron/src/lib/structures/CronTask.ts
+++ b/packages/cron/src/lib/structures/CronTask.ts
@@ -14,7 +14,7 @@ import type { CronJobOptions } from '../types/CronTaskTypes';
  * 	public constructor(context: CronTask.LoaderContext, options: CronTask.Options) {
  * 		super(context, {
  * 			...options,
- * 			cronTime: '* * * * *'
+ * 			pattern: '* * * * *'
  * 		});
  * 	}
  *

--- a/packages/cron/src/lib/structures/CronTaskStore.ts
+++ b/packages/cron/src/lib/structures/CronTaskStore.ts
@@ -73,7 +73,7 @@ export class CronTaskStore extends Store<CronTask, 'cron-tasks'> {
 
 	public override set(key: string, value: CronTask): this {
 		const { pattern, timezone, ...options } = value.options;
-		const { sentry, defaultTimezone } = this.container.cron;
+		const { sentry, defaultTimezone } = this.container.cronTasks;
 
 		// if a task with the same key already exists, stop it before creating a new one
 		if (this.has(key)) {

--- a/packages/cron/src/lib/structures/CronTaskStore.ts
+++ b/packages/cron/src/lib/structures/CronTaskStore.ts
@@ -100,7 +100,16 @@ export class CronTaskStore extends Store<CronTask, 'cron-tasks'> {
 					},
 					...options
 				},
-				sentry?.withMonitor(key, value.run.bind(value)) ?? value.run.bind(value)
+				() => {
+					if (sentry) {
+						return sentry.withMonitor(key, () => void value.run.bind(value)(), {
+							schedule: { type: 'crontab', value: pattern },
+							timezone: timeZone
+						});
+					}
+
+					return value.run.bind(value)();
+				}
 			);
 		} catch (error) {
 			value.error('Encountered an error while creating the cron job', error);

--- a/packages/cron/src/lib/structures/CronTaskStore.ts
+++ b/packages/cron/src/lib/structures/CronTaskStore.ts
@@ -1,6 +1,7 @@
 import { Store } from '@sapphire/pieces';
 import { Cron } from 'croner';
 import { CronTask } from './CronTask';
+import { normalizePattern } from '../utils/normalizePattern';
 
 export class CronTaskStore extends Store<CronTask, 'cron-tasks'> {
 	public constructor() {
@@ -103,10 +104,11 @@ export class CronTaskStore extends Store<CronTask, 'cron-tasks'> {
 					...options
 				},
 				() => {
-					if (sentry) {
+					// we only want to monitor cron patterns and not single-use tasks that croner supports
+					if (sentry && typeof pattern === 'string' && !pattern.includes(':')) {
 						return sentry.withMonitor(key, () => void value.run.bind(value)(), {
 							schedule: { type: 'crontab', value: pattern },
-							timezone: timeZone
+							timezone: timeZone ? normalizePattern(timeZone) : undefined
 						});
 					}
 

--- a/packages/cron/src/lib/types/CronTaskTypes.ts
+++ b/packages/cron/src/lib/types/CronTaskTypes.ts
@@ -1,14 +1,11 @@
-import type { CronJobParams } from 'cron';
-import type { CronTask } from '../structures/CronTask';
+import type { CronOptions } from 'croner';
 
 export interface CronTaskHandlerOptions {
 	/**
-	 * The default timezone to use for all cron tasks.
-	 * You can override this per task, using the timeZone option.
-	 * @see https://github.com/moment/luxon/blob/master/docs/zones.md#specifying-a-zone
-	 * @default 'system'
+	 * The default IANA timezone to use for all cron jobs.
+	 * You can override this per task, using the timezone option.
 	 */
-	defaultTimezone: string;
+	defaultTimezone?: string;
 
 	/**
 	 * The ability to opt-out of instrumenting cron jobs with Sentry.
@@ -19,18 +16,6 @@ export interface CronTaskHandlerOptions {
 	disableSentry: boolean;
 }
 
-export type CronJobOptions = Omit<CronJobParams<null, CronTask>, 'onTick' | 'onComplete' | 'start' | 'context' | 'utcOffset'>;
-
-/**
- * The @types/luxon package doesn't seem to be up-to-date with luxon.
- * Therefore, I have to manually add the ianaName getter to the FixedOffsetZone class.
- * The code can be found here: https://github.com/moment/luxon/blob/3e9983cd0680fdf7836fcee638d34e3edc682380/src/zones/fixedOffsetZone.js#L80C7-L80C15
- */
-declare module 'luxon' {
-	interface FixedOffsetZone {
-		/**
-		 * The IANA name of this zone, i.e. `Etc/UTC` or `Etc/GMT+/-nn`
-		 */
-		get ianaName(): string;
-	}
+export interface CronJobOptions extends Pick<CronOptions, 'maxRuns' | 'protect' | 'unref' | 'timezone'> {
+	pattern: string;
 }

--- a/packages/cron/src/lib/types/CronTaskTypes.ts
+++ b/packages/cron/src/lib/types/CronTaskTypes.ts
@@ -16,6 +16,12 @@ export interface CronTaskHandlerOptions {
 	disableSentry: boolean;
 }
 
-export interface CronJobOptions extends Pick<CronOptions, 'maxRuns' | 'protect' | 'unref' | 'timezone'> {
+export interface CronJobOptions extends Pick<CronOptions, 'maxRuns' | 'unref' | 'timezone'> {
 	pattern: string;
+	/**
+	 * If true, prevents the job from running if the previous execution is still in progress.
+	 * If the task has a protect method, it will be called if the job is blocked.
+	 * @default false
+	 */
+	protect?: boolean;
 }

--- a/packages/cron/src/lib/types/CronTaskTypes.ts
+++ b/packages/cron/src/lib/types/CronTaskTypes.ts
@@ -17,7 +17,7 @@ export interface CronTaskHandlerOptions {
 }
 
 export interface CronJobOptions extends Pick<CronOptions, 'maxRuns' | 'unref' | 'timezone'> {
-	pattern: string;
+	pattern: string | Date;
 	/**
 	 * If true, prevents the job from running if the previous execution is still in progress.
 	 * If the task has a protect method, it will be called if the job is blocked.

--- a/packages/cron/src/lib/utils/normalizePattern.ts
+++ b/packages/cron/src/lib/utils/normalizePattern.ts
@@ -1,0 +1,43 @@
+/*
+ * Credits to Sapphire for this
+ * https://github.com/sapphiredev/utilities/blob/main/packages/cron/src/lib/constants.ts#L26-L57
+ * https://github.com/sapphiredev/utilities/blob/main/packages/cron/src/lib/Cron.ts#L91
+ */
+
+const predefined = {
+	'@annually': '0 0 1 1 *',
+	'@yearly': '0 0 1 1 *',
+	'@monthly': '0 0 1 * *',
+	'@weekly': '0 0 * * 0',
+	'@daily': '0 0 * * *',
+	'@hourly': '0 * * * *'
+} as const;
+
+const cronTokens: Record<string, number> = {
+	jan: 1,
+	feb: 2,
+	mar: 3,
+	apr: 4,
+	may: 5,
+	jun: 6,
+	jul: 7,
+	aug: 8,
+	sep: 9,
+	oct: 10,
+	nov: 11,
+	dec: 12,
+	sun: 0,
+	mon: 1,
+	tue: 2,
+	wed: 3,
+	thu: 4,
+	fri: 5,
+	sat: 6
+} as const;
+
+const tokensRegex = new RegExp(Object.keys(cronTokens).join('|'), 'g');
+
+export function normalizePattern(pattern: string): string {
+	if (Reflect.has(predefined, pattern)) return Reflect.get(predefined, pattern);
+	return pattern.replace(tokensRegex, (match) => String(Reflect.get(cronTokens, match)));
+}

--- a/packages/cron/src/register.ts
+++ b/packages/cron/src/register.ts
@@ -6,7 +6,7 @@ import { CronTaskHandler, CronTaskStore } from './index';
 
 export class CronTaskPlugin extends Plugin {
 	public static override [preGenericsInitialization](this: SapphireClient, options: ClientOptions) {
-		container.cron = new CronTaskHandler(options.cron);
+		container.cronTasks = new CronTaskHandler(options.cronTasks);
 	}
 
 	public static override [postInitialization](this: SapphireClient) {
@@ -14,8 +14,8 @@ export class CronTaskPlugin extends Plugin {
 	}
 
 	public static override async [preLogin](this: SapphireClient) {
-		if (container.cron.disableSentry) return;
-		container.cron.sentry = await import('@sentry/node').catch(() => undefined);
+		if (container.cronTasks.disableSentry) return;
+		container.cronTasks.sentry = await import('@sentry/node').catch(() => undefined);
 	}
 
 	public static override [postLogin](this: SapphireClient) {

--- a/packages/cron/src/register.ts
+++ b/packages/cron/src/register.ts
@@ -19,7 +19,7 @@ export class CronTaskPlugin extends Plugin {
 	}
 
 	public static override [postLogin](this: SapphireClient) {
-		container.stores.get('cron-tasks').resumeAll();
+		this.stores.get('cron-tasks').resumeAll();
 	}
 }
 

--- a/packages/cron/src/register.ts
+++ b/packages/cron/src/register.ts
@@ -19,7 +19,7 @@ export class CronTaskPlugin extends Plugin {
 	}
 
 	public static override [postLogin](this: SapphireClient) {
-		container.cron.startAll();
+		container.stores.get('cron-tasks').resumeAll();
 	}
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -697,10 +697,8 @@ __metadata:
     "@favware/cliff-jumper": "npm:^6.0.0"
     "@favware/rollup-type-bundler": "npm:^4.0.0"
     "@sentry/node": "npm:^9.11.0"
-    "@types/luxon": "npm:^3.6.2"
     "@types/node": "npm:^22.14.0"
     concurrently: "npm:^9.1.2"
-    cron: "npm:^4.1.3"
     croner: "npm:^9.0.0"
     tsup: "npm:^8.4.0"
     tsx: "npm:^4.19.3"
@@ -1740,20 +1738,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/luxon@npm:^3.6.2":
-  version: 3.6.2
-  resolution: "@types/luxon@npm:3.6.2"
-  checksum: 10/73ca30059e0b1e352ce3a208837bc042e0bae9cf6e5b42f63de9ddfe15348a9e9bf9fcde3d4034038be24cb24adc579ae984cadff3bf70432e54fed1ad249d12
-  languageName: node
-  linkType: hard
-
-"@types/luxon@npm:~3.4.0":
-  version: 3.4.2
-  resolution: "@types/luxon@npm:3.4.2"
-  checksum: 10/fd89566e3026559f2bc4ddcc1e70a2c16161905ed50be9473ec0cfbbbe919165041408c4f6e06c4bcf095445535052e2c099087c76b1b38e368127e618fc968d
-  languageName: node
-  linkType: hard
-
 "@types/mysql@npm:2.15.26":
   version: 2.15.26
   resolution: "@types/mysql@npm:2.15.26"
@@ -2617,16 +2601,6 @@ __metadata:
     typescript:
       optional: true
   checksum: 10/8bdf1dfbb6fdb3755195b6886dc0649a3c742ec75afa4cb8da7b070936aed22a4f4e5b7359faafe03180358f311dbc300d248fd6586c458203d376a40cc77826
-  languageName: node
-  linkType: hard
-
-"cron@npm:^4.1.3":
-  version: 4.1.3
-  resolution: "cron@npm:4.1.3"
-  dependencies:
-    "@types/luxon": "npm:~3.4.0"
-    luxon: "npm:~3.6.0"
-  checksum: 10/518a6ccd4caf630c8abd4d0f23530c849369da4c6cdb4b8b8a608498db87e03f532d8e164ad203ca75c67ce8bf7c9e1b6f1008cd91d40b5c659b8acbd451c187
   languageName: node
   linkType: hard
 
@@ -4401,13 +4375,6 @@ __metadata:
   version: 11.1.0
   resolution: "lru-cache@npm:11.1.0"
   checksum: 10/5011011675ca98428902de774d0963b68c3a193cd959347cb63b781dad4228924124afab82159fd7b8b4db18285d9aff462b877b8f6efd2b41604f806c1d9db4
-  languageName: node
-  linkType: hard
-
-"luxon@npm:~3.6.0":
-  version: 3.6.1
-  resolution: "luxon@npm:3.6.1"
-  checksum: 10/35aad425607708c87af110a52c949190bc35b987770079ec8007ef2365cd29639413db3360d2883777aa01cb3ca5bdb37f42ee3e8e5a0dd277fe22e90cc8a786
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -701,6 +701,7 @@ __metadata:
     "@types/node": "npm:^22.14.0"
     concurrently: "npm:^9.1.2"
     cron: "npm:^4.1.3"
+    croner: "npm:^9.0.0"
     tsup: "npm:^8.4.0"
     tsx: "npm:^4.19.3"
     typescript: "npm:~5.4.5"
@@ -2626,6 +2627,13 @@ __metadata:
     "@types/luxon": "npm:~3.4.0"
     luxon: "npm:~3.6.0"
   checksum: 10/518a6ccd4caf630c8abd4d0f23530c849369da4c6cdb4b8b8a608498db87e03f532d8e164ad203ca75c67ce8bf7c9e1b6f1008cd91d40b5c659b8acbd451c187
+  languageName: node
+  linkType: hard
+
+"croner@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "croner@npm:9.0.0"
+  checksum: 10/b3cea758eedfe92e35c4ebae46c9db615565348ad898b5938fd94ea77abc5ff68d86539db248a1666b007b0726da642c9046879e8fd598220afcc87c8135e656
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
As suggested by a fellow user, I have replaced `cron` with `croner`. The differences can be found here: https://github.com/Hexagon/croner/tree/master?tab=readme-ov-file#why-another-javascript-cron-implementation

TODO:
Sentry cannot automatically instrument `croner`; thus, my implementation requires testing.
- Months and days must be in number format. The `croner` package handles this in its [CronPattern](https://github.com/Hexagon/croner/blob/master/src/pattern.ts#L435-L468) class, so I will likely have to make use of that.
- The cron pattern accepts providing a JS date object or an ISO 8601 string, which would run the task once. So, I would have to take care of this.
  
BREAKING CHANGE: The `cronTime` option has been replaced with `pattern`.
BREAKING CHANGE: The `timeZone` option has been replaced with `timezone`.
BREAKING CHANGE: The `cron` package has been replaced with `croner`.
BREAKING CHANGE: `container.cron.startAll()` and `container.cron.stopAll()` have been removed. Instead, you should pause and resume using the plugin's store.
BREAKING CHANGE: References to the word `cron` have been replaced with `cronTasks` for consistency. For example, `container.cron` is now `container.cronTasks` and `ClientOptions.cron` is now `ClientOptions.cronTasks`.