### PR TITLE
fix: correct the usage of the normalizePattern() function

### DIFF
--- a/packages/cron/src/lib/structures/CronTaskStore.ts
+++ b/packages/cron/src/lib/structures/CronTaskStore.ts
@@ -107,8 +107,8 @@ export class CronTaskStore extends Store<CronTask, 'cron-tasks'> {
 					// we only want to monitor cron patterns and not single-use tasks that croner supports
 					if (sentry && typeof pattern === 'string' && !pattern.includes(':')) {
 						return sentry.withMonitor(key, () => void value.run.bind(value)(), {
-							schedule: { type: 'crontab', value: pattern },
-							timezone: timeZone ? normalizePattern(timeZone) : undefined
+							schedule: { type: 'crontab', value: normalizePattern(pattern) },
+							timezone: timeZone
 						});
 					}
 


### PR DESCRIPTION
Not sure why I originally used the normalizePattern() function on the timezone, when it's for the pattern.

Nonetheless, I have now fixed this mistake.