### PR TITLE
chore(deps): update typescript

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,10 +5,6 @@
 		{
 			"matchDepTypes": ["engines"],
 			"enabled": false
-		},
-		{
-			"enabled": false,
-			"matchPackageNames": ["/typescript/"]
 		}
 	]
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"rimraf": "^6.0.1",
 		"tsup": "^8.5.0",
 		"turbo": "^2.5.3",
-		"typescript": "~5.4.5"
+		"typescript": "^5.8.3"
 	},
 	"commitlint": {
 		"extends": [

--- a/packages/cron/package.json
+++ b/packages/cron/package.json
@@ -56,7 +56,7 @@
 		"concurrently": "^9.1.2",
 		"tsup": "^8.5.0",
 		"tsx": "^4.19.4",
-		"typescript": "~5.4.5"
+		"typescript": "^5.8.3"
 	},
 	"homepage": "https://github.com/Kings-World/sapphire-plugins",
 	"repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -716,7 +716,7 @@ __metadata:
     croner: "npm:^9.0.0"
     tsup: "npm:^8.5.0"
     tsx: "npm:^4.19.4"
-    typescript: "npm:~5.4.5"
+    typescript: "npm:^5.8.3"
   languageName: unknown
   linkType: soft
 
@@ -747,7 +747,7 @@ __metadata:
     rimraf: "npm:^6.0.1"
     tsup: "npm:^8.5.0"
     turbo: "npm:^2.5.3"
-    typescript: "npm:~5.4.5"
+    typescript: "npm:^5.8.3"
   languageName: unknown
   linkType: soft
 
@@ -6161,6 +6161,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript@npm:^5.8.3":
+  version: 5.8.3
+  resolution: "typescript@npm:5.8.3"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10/65c40944c51b513b0172c6710ee62e951b70af6f75d5a5da745cb7fab132c09ae27ffdf7838996e3ed603bb015dadd099006658046941bd0ba30340cc563ae92
+  languageName: node
+  linkType: hard
+
 "typescript@npm:~5.4.5":
   version: 5.4.5
   resolution: "typescript@npm:5.4.5"
@@ -6178,6 +6188,16 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10/97920a082ffc57583b1cb6bc4faa502acc156358e03f54c7fc7fdf0b61c439a717f4c9070c449ee9ee683d4cfc3bb203127c2b9794b2950f66d9d307a4ff262c
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@npm%3A^5.8.3#optional!builtin<compat/typescript>":
+  version: 5.8.3
+  resolution: "typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=5786d5"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10/b9b1e73dabac5dc730c041325dbd9c99467c1b0d239f1b74ec3b90d831384af3e2ba973946232df670519147eb51a2c20f6f96163cea2b359f03de1e2091cc4f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Now that discord.js 14.9 has been released with the https://github.com/discordjs/discord.js/pull/10773 PR changes, we are no longer required to be stuck on 5.4.