### PR TITLE
chore(deps): update typescript to v6

### DIFF
--- a/.yarn/patches/tsup-npm-8.5.1-41f4f7d59b.patch
+++ b/.yarn/patches/tsup-npm-8.5.1-41f4f7d59b.patch
@@ -1,0 +1,12 @@
+diff --git a/dist/rollup.js b/dist/rollup.js
+index e128b61b9558318b9f86dc11d72c31f09a8eb7db..5068f0918d96c62e06ecb7b2113c717da569baae 100644
+--- a/dist/rollup.js
++++ b/dist/rollup.js
+@@ -6834,7 +6834,6 @@ var getRollupConfig = async (options) => {
+           tsconfig: options.tsconfig,
+           compilerOptions: {
+             ...compilerOptions,
+-            baseUrl: compilerOptions.baseUrl || ".",
+             // Ensure ".d.ts" modules are generated
+             declaration: true,
+             // Skip ".js" generation

--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
 		"lint-staged": "^16.4.0",
 		"prettier": "^3.8.3",
 		"rimraf": "^6.1.3",
-		"tsup": "^8.5.1",
+		"tsup": "patch:tsup@npm%3A8.5.1#~/.yarn/patches/tsup-npm-8.5.1-41f4f7d59b.patch",
 		"turbo": "^2.9.6",
-		"typescript": "^5.9.3"
+		"typescript": "^6.0.3"
 	},
 	"commitlint": {
 		"extends": [

--- a/packages/cron/package.json
+++ b/packages/cron/package.json
@@ -54,9 +54,9 @@
 		"@sentry/node": "^10.50.0",
 		"@types/node": "^24.12.2",
 		"concurrently": "^9.2.1",
-		"tsup": "^8.5.1",
+		"tsup": "patch:tsup@npm%3A8.5.1#~/.yarn/patches/tsup-npm-8.5.1-41f4f7d59b.patch",
 		"tsx": "^4.21.0",
-		"typescript": "^5.9.3"
+		"typescript": "^6.0.3"
 	},
 	"homepage": "https://github.com/Kings-World/sapphire-plugins",
 	"repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -723,9 +723,9 @@ __metadata:
     "@types/node": "npm:^24.12.2"
     concurrently: "npm:^9.2.1"
     croner: "npm:^10.0.1"
-    tsup: "npm:^8.5.1"
+    tsup: "patch:tsup@npm%3A8.5.1#~/.yarn/patches/tsup-npm-8.5.1-41f4f7d59b.patch"
     tsx: "npm:^4.21.0"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -754,9 +754,9 @@ __metadata:
     lint-staged: "npm:^16.4.0"
     prettier: "npm:^3.8.3"
     rimraf: "npm:^6.1.3"
-    tsup: "npm:^8.5.1"
+    tsup: "patch:tsup@npm%3A8.5.1#~/.yarn/patches/tsup-npm-8.5.1-41f4f7d59b.patch"
     turbo: "npm:^2.9.6"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -5739,7 +5739,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tsup@npm:^8.5.1":
+"tsup@npm:8.5.1":
   version: 8.5.1
   resolution: "tsup@npm:8.5.1"
   dependencies:
@@ -5778,6 +5778,48 @@ __metadata:
     tsup: dist/cli-default.js
     tsup-node: dist/cli-node.js
   checksum: 10/f1927ec2dda93b218b39cd1cac1040902eef66e026261f5c265197c2f660cb5b9e1fb89353d50de5c6a5616463c02800e87e1daad7620b9c9051221d93c66824
+  languageName: node
+  linkType: hard
+
+"tsup@patch:tsup@npm%3A8.5.1#~/.yarn/patches/tsup-npm-8.5.1-41f4f7d59b.patch":
+  version: 8.5.1
+  resolution: "tsup@patch:tsup@npm%3A8.5.1#~/.yarn/patches/tsup-npm-8.5.1-41f4f7d59b.patch::version=8.5.1&hash=52fb72"
+  dependencies:
+    bundle-require: "npm:^5.1.0"
+    cac: "npm:^6.7.14"
+    chokidar: "npm:^4.0.3"
+    consola: "npm:^3.4.0"
+    debug: "npm:^4.4.0"
+    esbuild: "npm:^0.27.0"
+    fix-dts-default-cjs-exports: "npm:^1.0.0"
+    joycon: "npm:^3.1.1"
+    picocolors: "npm:^1.1.1"
+    postcss-load-config: "npm:^6.0.1"
+    resolve-from: "npm:^5.0.0"
+    rollup: "npm:^4.34.8"
+    source-map: "npm:^0.7.6"
+    sucrase: "npm:^3.35.0"
+    tinyexec: "npm:^0.3.2"
+    tinyglobby: "npm:^0.2.11"
+    tree-kill: "npm:^1.2.2"
+  peerDependencies:
+    "@microsoft/api-extractor": ^7.36.0
+    "@swc/core": ^1
+    postcss: ^8.4.12
+    typescript: ">=4.5.0"
+  peerDependenciesMeta:
+    "@microsoft/api-extractor":
+      optional: true
+    "@swc/core":
+      optional: true
+    postcss:
+      optional: true
+    typescript:
+      optional: true
+  bin:
+    tsup: dist/cli-default.js
+    tsup-node: dist/cli-node.js
+  checksum: 10/2229003ceac0721e8c9e2b4c3e1b9af895ba3b312e322435e6eb4333bdcfb1cb58067a6237b6720d0558cb5a740e3cbfd0b12bef2f5ed230b43da153a6ea7463
   languageName: node
   linkType: hard
 
@@ -5849,13 +5891,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.5.2, typescript@npm:^5.9.3":
+"typescript@npm:^5.5.2":
   version: 5.9.3
   resolution: "typescript@npm:5.9.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10/c089d9d3da2729fd4ac517f9b0e0485914c4b3c26f80dc0cffcb5de1719a17951e92425d55db59515c1a7ddab65808466debb864d0d56dcf43f27007d0709594
+  languageName: node
+  linkType: hard
+
+"typescript@npm:^6.0.3":
+  version: 6.0.3
+  resolution: "typescript@npm:6.0.3"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10/0ef2357a4cffd916b52b683a021cdab0f81eea4e9aa35f2d254581c9a5106da02224e3392e1b0ed42b7a48f80c966e5f52b8e1a27941fa0523c1705a9c2e0330
   languageName: node
   linkType: hard
 
@@ -5869,13 +5921,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^5.5.2#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.9.3#optional!builtin<compat/typescript>":
+"typescript@patch:typescript@npm%3A^5.5.2#optional!builtin<compat/typescript>":
   version: 5.9.3
   resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10/696e1b017bc2635f4e0c94eb4435357701008e2f272f553d06e35b494b8ddc60aa221145e286c28ace0c89ee32827a28c2040e3a69bdc108b1a5dc8fb40b72e3
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@npm%3A^6.0.3#optional!builtin<compat/typescript>":
+  version: 6.0.3
+  resolution: "typescript@patch:typescript@npm%3A6.0.3#optional!builtin<compat/typescript>::version=6.0.3&hash=5786d5"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10/22b67a18dafedf9b1468b64ca20d9aa02ea61d449b65413d8aa6552aeb63f52ef369e86beb25b6b4c91a803d9726ee5c196f391a9b64201263263410a4223ee6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Updates the project to TypeScript v6. However, since tsup is no longer maintained, I have patched it to remove `baseUrl` because I prefer not to use the `ignoreDeprecations` option that the TS config offers.

The maintainers of tsup recommend migrating to tsdown. I will do that at a later date.