### PR TITLE
chore(vscode): replace deprecated typescript settings with their replacements

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
-	"typescript.tsdk": "node_modules/typescript/lib",
-	"typescript.enablePromptUseWorkspaceTsdk": true,
+	"js/ts.tsdk.path": "node_modules/typescript/lib",
+	"js/ts.tsdk.promptToUseWorkspaceVersion": true,
 	"sonarlint.connectedMode.project": {
 		"connectionId": "kings-world",
 		"projectKey": "Kings-World_sapphire-plugins"


### PR DESCRIPTION
Replaces the deprecated TypeScript settings with the recent alternatives. 

`typescript.tsdk`
This setting is deprecated. Use js/ts.tsdk.path instead.

`typescript.enablePromptUseWorkspaceTsdk`
This setting is deprecated. Use js/ts.tsdk.promptToUseWorkspaceVersion instead.