### PR TITLE
refactor: prefer string.replaceAll() over string.replace()

### DIFF
--- a/packages/cron/src/lib/utils/normalizePattern.ts
+++ b/packages/cron/src/lib/utils/normalizePattern.ts
@@ -39,5 +39,5 @@ const tokensRegex = new RegExp(Object.keys(cronTokens).join('|'), 'g');
 
 export function normalizePattern(pattern: string): string {
 	if (Reflect.has(predefined, pattern)) return Reflect.get(predefined, pattern);
-	return pattern.replace(tokensRegex, (match) => String(Reflect.get(cronTokens, match)));
+	return pattern.replaceAll(tokensRegex, (match) => String(Reflect.get(cronTokens, match)));
 }

--- a/scripts/clean-register-imports.mts
+++ b/scripts/clean-register-imports.mts
@@ -17,8 +17,8 @@ for (const path of paths) {
 	const fileContent = await readFile(fullPathUrl, { encoding: 'utf8' });
 
 	const cleanedUpContent = fileContent
-		.replace(cleanupImportsRegex, '')
-		.replace(cleanupNewlineRegex, '\n\n')
+		.replaceAll(cleanupImportsRegex, '')
+		.replaceAll(cleanupNewlineRegex, '\n\n')
 		.replace('import "./index.js";', 'import "./index.cjs";');
 
 	await writeFile(fullPathUrl, cleanedUpContent, { encoding: 'utf8' });


### PR DESCRIPTION
SonarQube recommends strings use `replaceAll()` instead of `replace()` with global regex.