### PR TITLE
chore: fix yarn wildcards and set zed config to jsonc

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,7 +3,8 @@
 yarn.lock linguist-generated
 .pnp.* binary linguist-generated
 .yarn/** linguist-vendored
-.yarn/releases/** binary
-.yarn/plugins/** binary
+.yarn/releases/* binary
+.yarn/plugins/**/* binary
 
 .vscode/*.json linguist-language=jsonc
+.zed/*.json linguist-language=jsonc


### PR DESCRIPTION
Fixes git attributes for yarn plugins to have `**/*` as the wildcard. In addition, changed releases to be a singular wildcard (`*`).

This matches Yarn v4 init git attributes, which are:

```
/.yarn/**            linguist-vendored
/.yarn/releases/*    binary
/.yarn/plugins/**/*  binary
/.pnp.*              binary linguist-generated
```

In addition, I have added Zed so that its config will show as JSONC instead of regular JSON.