### PR TITLE
chore: update code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,8 @@
-/packages/cron/**/*.ts @SerenModz21
+* @SerenModz21
 
-package.json @renovate-approve
+# reset for renovate prs
+/.github/workflows/*.yml
+/.github/renovate.json
+/packages/*/package.json
+/package.json
+/yarn.lock

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
 /packages/cron/**/*.ts @SerenModz21
+
+package.json @renovate-approve


### PR DESCRIPTION
Give myself ownership of all files other than those that Renovate alters. This is required because GitHub does not currently allow bots/apps to have ownership, which thus prevents Renovate from being able to auto-merge PRs.

References:
- https://github.com/orgs/community/discussions/23064
- https://github.com/orgs/community/discussions/108490